### PR TITLE
Specify `Ndh=32`

### DIFF
--- a/draft-wahby-cfrg-hpke-kem-secp256k1.md
+++ b/draft-wahby-cfrg-hpke-kem-secp256k1.md
@@ -129,6 +129,9 @@ This document requests/registers a new entry to the "HPKE KEM Identifiers"
  Nsk:
  : 32
 
+ Ndh:
+ : 32
+
  Auth:
  : yes
 


### PR DESCRIPTION
Every DHKEM has an [`Ndh`](https://www.rfc-editor.org/rfc/rfc9180.html#section-4.1), specifying the byte length of the DH shared secret. I believe that is 32 in this case.